### PR TITLE
rustdoc-json: make variant Tuple contain `Vec<Id>` instead of `Vec<Type>`

### DIFF
--- a/src/librustdoc/json/conversions.rs
+++ b/src/librustdoc/json/conversions.rs
@@ -576,22 +576,11 @@ impl FromWithTcx<clean::VariantStruct> for Struct {
 }
 
 impl FromWithTcx<clean::Variant> for Variant {
-    fn from_tcx(variant: clean::Variant, tcx: TyCtxt<'_>) -> Self {
+    fn from_tcx(variant: clean::Variant, _tcx: TyCtxt<'_>) -> Self {
         use clean::Variant::*;
         match variant {
             CLike => Variant::Plain,
-            Tuple(fields) => Variant::Tuple(
-                fields
-                    .into_iter()
-                    .map(|f| {
-                        if let clean::StructFieldItem(ty) = *f.kind {
-                            ty.into_tcx(tcx)
-                        } else {
-                            unreachable!()
-                        }
-                    })
-                    .collect(),
-            ),
+            Tuple(fields) => Variant::Tuple(ids(fields)),
             Struct(s) => Variant::Struct(ids(s.fields)),
         }
     }

--- a/src/rustdoc-json-types/lib.rs
+++ b/src/rustdoc-json-types/lib.rs
@@ -272,7 +272,7 @@ pub struct Enum {
 #[serde(tag = "variant_kind", content = "variant_inner")]
 pub enum Variant {
     Plain,
-    Tuple(Vec<Type>),
+    Tuple(Vec<Id>),
     Struct(Vec<Id>),
 }
 


### PR DESCRIPTION
Proof of concept.